### PR TITLE
Explicitly list packages in setup.py instead of using find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 if __name__ == '__main__':
@@ -12,7 +12,7 @@ if __name__ == '__main__':
         long_description=open('README.rst').read(),
         keywords=['salesforce', 'soql', 'salesforce.com'],
         license='MIT',
-        packages=find_packages(exclude=('test*')),
+        packages=['soql'],
         install_requires=[
             'python-dateutil',
             'six',


### PR DESCRIPTION
The package isn't getting built properly. This seems to fix the problem, although I haven't had time to dig into why yet.